### PR TITLE
Improving tilt calculation

### DIFF
--- a/script.py
+++ b/script.py
@@ -265,7 +265,7 @@ def getPlayer(player):
             if not games[i]['stats']['win'] :
                 tiltFactor += 10 - i
     tiltFactor *= 10.0 / 55
-    tiltFactor = int((tiltFactor * 10) + 0.5) / 10.0
+    tiltFactor = round(tiltFactor)
     if not wasGame:
         tiltFactor = "Unknown"
     else:


### PR DESCRIPTION
Thinking about converting win loss of past games to binary; 0 for wins, 1 for losses

Example:
We play 3 games, with the result
Game 1: Loss --> 1
Game 2: Loss --> 1
Game 3: Victory --> 0

Converting to binary, we get: 011
The binary value then gets converted back to a percentile, then to decimal.

This way, the more recent games are weighted even more than they are currently. The player is more likely to be tilted from the most recent game, than the game from two games ago.

Also changed to use python's built-in round function instead of a non-native implementation.
